### PR TITLE
连连支付域名更改

### DIFF
--- a/lib/serverurlconfig.js
+++ b/lib/serverurlconfig.js
@@ -1,7 +1,7 @@
 module.exports = {
-	pay_url:"https://yintong.com.cn/payment/bankgateway.htm", // 连连支付WEB收银台支付服务地址
-	query_user_bankcard_url:"https://yintong.com.cn/traderapi/userbankcard.htm", // 用户已绑定银行卡列表查询
-  query_bankcard_url:"https://yintong.com.cn/traderapi/bankcardquery.htm", //银行卡卡bin信息查询
-  llpay_gateway_new:"https://yintong.com.cn/llpayh5/authpay.htm",//连连支付 WAP 认证支付接口
+  pay_url:"https://cashier.lianlianpay.com/payment/bankgateway.htm", // 连连支付WEB收银台支付服务地址
+	query_user_bankcard_url:"https://traderapi.lianlianpay.com/userbankcard.htm", // 用户已绑定银行卡列表查询
+  query_bankcard_url:"https://traderapi.lianlianpay.com/bankcardquery.htm", //银行卡卡bin信息查询
+  llpay_gateway_new:"https://wap.lianlianpay.com/authpay.htm",//连连支付 WAP 认证支付接口
   llpay_query_url:"https://queryapi.lianlianpay.com/orderquery.htm"//连连支付结果查询服务接口
 }

--- a/test/llpayapi.js
+++ b/test/llpayapi.js
@@ -53,7 +53,7 @@ describe('#doQuery()',function(){
 		});
 		before(function(){
 			muk(request,'post',function(json, callback){
-				describe('#json.url should be "https://yintong.com.cn/traderapi/orderquery.htm"#',function(){
+				describe('#json.url should be "https://queryapi.lianlianpay.com/orderquery.htm"#',function(){
 					var body = JSON.parse(json.body);
 					// console.log(body);
 					//地址必须是"https://yintong.com.cn/traderapi/orderquery.htm"


### PR DESCRIPTION
1）web支付网关 
   切换方法：https://yintong.com.cn/payment/ 替换为  https://cashier.lianlianpay.com/payment/
2）手机wap支付网关（旧版+新版）
    wap旧版切换方法：https://yintong.com.cn/wap/ 替换为 https://wap.lianlianpay.com/wap/
    wap新版切换方法：https://yintong.com.cn/llpayh5/ 替换为 https://wap.lianlianpay.com/
3）API支付接口
    切换方法： https://yintong.com.cn/traderapi/ 替换为 https://traderapi.lianlianpay.com/
4）查询服务API接口
    切换方法：https://yintong.com.cn/queryapi/ 替换为 https://queryapi.lianlianpay.com/